### PR TITLE
Add re-encryption with new vendors on production

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ This system aims to implement a hexagonal architecture. Simply put, this means t
 ## Troubleshooting 
 
 - Ensure your AWS Security Tokens are set! They should be saved on your machine, and you configure them by running `aws configure` (assuming you have the AWS CLI set up)
+
+## TODO 
+- go into architecture
+- go into database structure (how we have a global secondary index on pk in vendor because we use it for adding re-encryption keys)

--- a/pkg/producing/connections.go
+++ b/pkg/producing/connections.go
@@ -1,0 +1,13 @@
+package producing
+
+// MetadataResponse is the vendor metadata used to sync vendors on data production
+type MetadataResponse struct {
+	VendorConnections []string `json:"connections"`
+	Vendors           []string `json:"vendors"`
+}
+
+// ReencryptionKeysRequest is sent when adding new re-encryption keys to a pre-existing vendor on produce
+type ReencryptionKeysRequest struct {
+	Connections map[string][]string `json:"connections"`
+	PublicKey   string              `json:"pk"`
+}

--- a/pkg/producing/metadata.go
+++ b/pkg/producing/metadata.go
@@ -1,7 +1,0 @@
-package producing
-
-// MetadataResponse is the vendor metadata used to sync vendors on data production
-type MetadataResponse struct {
-	VendorConnections []string `json:"connections"`
-	Vendors           []string `json:"vendors"`
-}

--- a/pkg/producing/service.go
+++ b/pkg/producing/service.go
@@ -4,12 +4,14 @@ package producing
 type repository interface {
 	Produce(ObservationRequest) error
 	GetVendorComparisonMetadata(ObservationRequest) (*MetadataResponse, error)
+	AddReencryptionKeys(ReencryptionKeysRequest) error
 }
 
 // Service provides producing operations
 type Service interface {
 	Produce(ObservationRequest) error
 	GetVendorComparisonMetadata(ObservationRequest) (*MetadataResponse, error)
+	AddReencryptionKeys(ReencryptionKeysRequest) error
 }
 
 type service struct {
@@ -36,4 +38,12 @@ func (s *service) GetVendorComparisonMetadata(o ObservationRequest) (*MetadataRe
 		return nil, err
 	}
 	return metadata, nil
+}
+
+func (s *service) AddReencryptionKeys(r ReencryptionKeysRequest) error {
+	err := s.r.AddReencryptionKeys(r)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/storage/dynamo/repository.go
+++ b/pkg/storage/dynamo/repository.go
@@ -23,7 +23,6 @@ import (
 )
 
 // Storage keeps data in dynamo
-// TODO right now these vars are never used. Should we, instead of doing unmarhsal into a new &vendor, for example, do it into this vendor here?
 type Storage struct {
 	vendor      Vendor
 	observation Observation
@@ -342,4 +341,82 @@ func (d *Storage) GetVendorComparisonMetadata(o producing.ObservationRequest) (*
 	}
 
 	return &response, nil
+}
+
+// AddReencryptionKeys adds newly-created re-encryption keys for pre-existing vendors
+func (d *Storage) AddReencryptionKeys(r producing.ReencryptionKeysRequest) error {
+	// Initialize AWS session
+	svc := SetupAWSSession()
+
+	// Get connections of requesting vendor and username, since as of 07/2020, DynamoDB doesn't support updates on GSIs
+	input := &dynamodb.ScanInput{
+		ExpressionAttributeNames: map[string]*string{
+			"#connections": aws.String("connections"),
+			"#username":    aws.String("username"),
+		},
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":pk": {
+				S: aws.String(r.PublicKey),
+			},
+		},
+		FilterExpression:     aws.String("pk = :pk"),
+		ProjectionExpression: aws.String("#connections, #username"),
+		TableName:            aws.String("vendor"),
+	}
+
+	connectionsResp, err := svc.Scan(input)
+	if err != nil {
+		return err
+	}
+
+	username := connectionsResp.Items[0]["username"].S
+	connections := connectionsResp.Items[0]["connections"].M
+
+	// Add each new connection to the map
+	for k, v := range r.Connections {
+		dynamoV := make([]*dynamodb.AttributeValue, 2)
+		dynamoV[0] = &dynamodb.AttributeValue{
+			S: aws.String(v[0]),
+		}
+		dynamoV[1] = &dynamodb.AttributeValue{
+			S: aws.String(v[1]),
+		}
+
+		connectionsResp.Items[0]["connections"].M[k] = &dynamodb.AttributeValue{
+			L: []*dynamodb.AttributeValue{
+				{
+					S: aws.String(v[0]),
+				},
+				{
+					S: aws.String(v[1]),
+				},
+			},
+		}
+	}
+
+	// Update connections in DynamoDB
+	updateInput := &dynamodb.UpdateItemInput{
+		ExpressionAttributeNames: map[string]*string{
+			"#connections": aws.String("connections"),
+		},
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":connections": {
+				M: connections,
+			},
+		},
+		Key: map[string]*dynamodb.AttributeValue{
+			"username": {
+				S: username,
+			},
+		},
+		TableName:        aws.String("vendor"),
+		UpdateExpression: aws.String("SET #connections = :connections"),
+	}
+
+	_, err = svc.UpdateItem(updateInput)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
closes #16 

- Adds functionality so that when a vendor produces data, they also create re-encryption keys between themselves, and any vendors that joined the system since last producing data. This allows all vendors producing data to be up-to-date and start consuming data immediately. 

Prior to this, a newly-created vendor could only produce data for others to consume, not vice versa.

**Example:**
1. Vendor A creates a Supertype account, and adds a listener for `caloriesBurned`
2. Vendor B, who previously had no re-encryption keys to send data from B->A, produces data to `caloriesBurned`.
3. On production, Vendor B now also creates re-encryption keys from B->A
4. When Vendor A goes to consume this `caloriesBurned` observation, it will be able to get re-encryption keys from B->A

**NOTE:** This may have throw edge cases where the re-encryption keys will not be immediately populated, and there may be delays between when re-encryption keys are created and when data can be consumed.

## Future work
1. Do this in some type of asynchronous subroutine so that this functionality doesn't greatly slow down the consumption process
2. Move all lookups to Elasticsearch
3. **We still need a system for vendors to be able to create an account and begin consuming _old_ data, with this system only new observations are able to be consumed**