### PR TITLE
Producing notifies all subscribed consumers

### DIFF
--- a/cmd/supertype/main.go
+++ b/cmd/supertype/main.go
@@ -17,17 +17,18 @@ import (
 )
 
 func main() {
-	// Set up storage. Can easily add more and interchange as development continues
+	// Initialize storage
 	persistentStorage := new(dynamo.Storage)
 	cacheStorage := new(redis.Storage)
 
-	// Initialize services. Can easily add more and interchange as development continues
+	// Initialize services
 	authenticator := authenticating.NewService(persistentStorage)
 	dashboard := dashboard.NewService(persistentStorage)
 	producing := producing.NewService(persistentStorage)
 	consuming := consuming.NewService(persistentStorage)
 	cache := caching.NewService(cacheStorage)
 
+	// Initialize routers and startup server
 	httpRouter := rest.Router(authenticator, producing, consuming, dashboard, cache)
 	wsRouter := websocket.Router(cache)
 	// todo is this the best way to do this?

--- a/pkg/caching/service.go
+++ b/pkg/caching/service.go
@@ -2,14 +2,12 @@ package caching
 
 // Repository provides access to relevant storage
 type repository interface {
-	GenerateConnectionID() (*string, error)
 	Subscribe(WSObservationRequest) error
 	GetSubscribers(ObservationRequest) (*[]string, error)
 }
 
 // Service provides consuming operations
 type Service interface {
-	GenerateConnectionID() (*string, error)
 	Subscribe(WSObservationRequest) error
 	GetSubscribers(ObservationRequest) (*[]string, error)
 }
@@ -21,15 +19,6 @@ type service struct {
 // NewService creates a consuming service with the necessary dependencies
 func NewService(r repository) Service {
 	return &service{r}
-}
-
-// GenerateConnectionID adds specified attributes to relevant Redis lists
-func (s *service) GenerateConnectionID() (*string, error) {
-	observation, err := s.r.GenerateConnectionID()
-	if err != nil {
-		return nil, err
-	}
-	return observation, err
 }
 
 // Subscribe adds specified attributes to relevant Redis lists

--- a/pkg/http/httpObjects.go
+++ b/pkg/http/httpObjects.go
@@ -1,0 +1,24 @@
+package http
+
+import "github.com/gorilla/websocket"
+
+// Message is the incoming message
+type Message struct {
+	Type int    `json:"type"`
+	Body string `json:"body"`
+}
+
+// Pool is the current pool the client is subscribing to
+type Pool struct {
+	Register   chan *Client
+	Unregister chan *Client
+	Clients    map[*Client]bool
+	Broadcast  chan Message
+}
+
+// Client is the current WebSocket client
+type Client struct {
+	ID   string
+	Conn *websocket.Conn
+	Pool *Pool
+}

--- a/pkg/http/rest/handler.go
+++ b/pkg/http/rest/handler.go
@@ -2,11 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"strings"
-
-	"github.com/super-type/supertype/internal/utils"
 
 	"github.com/gorilla/mux"
 	"github.com/super-type/supertype/pkg/authenticating"
@@ -200,51 +196,6 @@ func produce(p producing.Service, cache caching.Service) func(w http.ResponseWri
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
-		}
-
-		// TODO this should probably be a separate goroutine?
-		// TODO this part should probably all be in the websocket handler...
-		obs := caching.ObservationRequest{
-			Attribute:   observation.Attribute,
-			SupertypeID: observation.SupertypeID,
-			PublicKey:   observation.PublicKey,
-			SkHash:      observation.SkHash,
-		}
-
-		// Get all connections subscribed to the given attribute
-		subscribers, err := cache.GetSubscribers(obs)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		fmt.Printf("subscribers: %v\n", subscribers)
-
-		// todo this maybe shouldn't be a string array but a map with the pk as key and object containing the metadata as the value
-		// todo this is really pivotal around encryption. If we don't have encryption, this becomes a lot faster
-		// todo if we keep encryption, we'll need to load all re-encryption info into local memory on startup
-		// todo without encryption, we can just do this all within the Produce function using the incoming data
-		var pkList []string
-
-		// Iterate through each connection
-		for _, subscriber := range *subscribers {
-			// Break pipe-delimited subscriber into string array
-			subscriberMetadata := strings.Split(subscriber, "|")
-
-			// Get the connection ID
-			// connSubscriber := subscriberMetadata[0]
-
-			// Get the public key.
-			pkSubscriber := subscriberMetadata[1]
-
-			if !utils.Contains(pkList, pkSubscriber) {
-				// Get the necessary connection metadata from DynamoDB
-			} else {
-				// Get the necessary connection metadata from pkList
-			}
-
-			// Attach that metadata to an outgoing response via WebSocket
-
-			// Send that data via WebSocket to the appropriate connection
 		}
 
 		json.NewEncoder(w).Encode("OK")

--- a/pkg/http/util.go
+++ b/pkg/http/util.go
@@ -3,10 +3,13 @@ package http
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"log"
 	"net/http"
 	"os"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/fatih/color"
 	"github.com/joho/godotenv"
 	"github.com/super-type/supertype/pkg/authenticating"
 )
@@ -51,4 +54,65 @@ func LocalHeaders(w http.ResponseWriter, r *http.Request) (*json.Decoder, error)
 
 	decoder := json.NewDecoder(r.Body)
 	return decoder, nil
+}
+
+// NewPool creates a new Pool
+func NewPool() *Pool {
+	return &Pool{
+		Register:   make(chan *Client),
+		Unregister: make(chan *Client),
+		Clients:    make(map[*Client]bool),
+		Broadcast:  make(chan Message),
+	}
+}
+
+// Start starts WebSocket process
+func (pool *Pool) Start() {
+	for {
+		select {
+		// Connect to Supertype
+		case client := <-pool.Register:
+			pool.Clients[client] = true
+			fmt.Println("Size of Connection Pool: ", len(pool.Clients))
+			for client := range pool.Clients {
+				color.Cyan("New connection on " + client.ID)
+				client.Conn.WriteJSON(Message{Type: 3, Body: "New user joined " + client.ID})
+			}
+			break
+
+		// Disconnect from Supertype
+		case client := <-pool.Unregister:
+			delete(pool.Clients, client)
+			fmt.Println("Size of Connection Pool: ", len(pool.Clients))
+			for client := range pool.Clients {
+				color.Cyan("Client disconnecting from " + client.ID)
+				client.Conn.WriteJSON(Message{Type: 1, Body: "Client disconnecting from " + client.ID})
+			}
+			break
+		}
+	}
+}
+
+// Read constantly listens for new messages coming through on this client's WS connection
+func (c *Client) Read() {
+	defer func() {
+		c.Pool.Unregister <- c
+		c.Conn.Close()
+	}()
+
+	for {
+		messageType, p, err := c.Conn.ReadMessage()
+		if err != nil {
+			log.Printf("Err: %v\n", err)
+			return
+		}
+
+		message := Message{
+			Type: messageType,
+			Body: string(p),
+		}
+		// todo we maybe want to loop through the Pool for relevant Clients here too...?
+		c.Pool.Broadcast <- message
+		fmt.Printf("Message Received: %v\n", message)
+	}
 }

--- a/pkg/http/websocket/handler.go
+++ b/pkg/http/websocket/handler.go
@@ -2,18 +2,46 @@ package websocket
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 
+	"github.com/fatih/color"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/super-type/supertype/pkg/caching"
+	httpUtil "github.com/super-type/supertype/pkg/http"
 )
+
+// PoolMap is a map of all pools with key of the form <attribute>|<supertypeID>
+// todo move this out of memory
+var poolMap map[string]httpUtil.Pool
+
+// BroadcastForSpecificPool sends a message to all members of a specific pool
+// todo move this into util once poolMap is out of memory
+func BroadcastForSpecificPool(poolID string, data string) {
+	pool := poolMap[poolID]
+	for client := range pool.Clients {
+		message := httpUtil.Message{
+			Type: 1,
+			Body: data,
+		}
+
+		err := client.Conn.WriteJSON(message)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+}
 
 // Router is the main router for the application
 func Router(c caching.Service) *mux.Router {
 	router := mux.NewRouter()
+	poolMap = make(map[string]httpUtil.Pool)
 
+	// todo maybe we can store PoolIDs in Redis and check to see if it's been started yet - adding to it if so and starting it if not
+	color.Cyan("Starting pool...")
 	router.HandleFunc("/consumeWS", consumeWS(c)).Methods("GET", "OPTIONS")
 	return router
 }
@@ -30,48 +58,60 @@ func consumeWS(c caching.Service) func(w http.ResponseWriter, r *http.Request) {
 			return true
 		}
 
-		// todo how do we know which connection is which. Generating our own connection
-		//     ID and putting it in Redis doesn't suffice when we have to actually send data to a specific connection....
-		ws, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		cid, err := c.GenerateConnectionID()
+		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		// todo should we write this as a different message type as well? Like 3 or something?
-		err = ws.WriteMessage(1, []byte(*cid))
+		err = conn.WriteMessage(1, []byte("Subscribed"))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		for {
-			// read in a message
-			messageType, p, _ := ws.ReadMessage()
-			if err != nil {
-				log.Println(err)
-				return
-			}
-			if messageType == 2 {
-				var obs caching.WSObservationRequest
-				err := json.Unmarshal(p, &obs)
-				if err != nil {
-					return
-				}
-				err = c.Subscribe(obs)
-				if err != nil {
-					return
-				}
-				if err := ws.WriteMessage(messageType, []byte("Successfully subscribed")); err != nil {
-					return
-				}
-			}
+		// client.Read()
+		_, p, err := conn.ReadMessage()
+		if err != nil {
+			log.Printf("Err: %v\n", err)
+			return
 		}
+
+		var observation caching.WSObservationRequest
+		err = json.Unmarshal(p, &observation)
+		if err != nil {
+			return
+		}
+
+		// todo this should probably be moved within caching service once we've moved poolMap out of memory
+		if _, ok := poolMap[observation.Attribute+"|"+observation.SupertypeID]; !ok {
+			pool := httpUtil.NewPool()
+			poolMap[observation.Attribute+"|"+observation.SupertypeID] = *pool
+			go pool.Start()
+
+			client := &httpUtil.Client{
+				ID:   observation.Attribute + "|" + observation.SupertypeID,
+				Conn: conn,
+				Pool: pool,
+			}
+
+			// We register this client on this specific pool
+			pool.Register <- client
+
+			poolMap[observation.Attribute+"|"+observation.SupertypeID] = *pool
+		} else {
+			pool := poolMap[observation.Attribute+"|"+observation.SupertypeID]
+
+			client := &httpUtil.Client{
+				ID:   observation.Attribute + "|" + observation.SupertypeID,
+				Conn: conn,
+				Pool: &pool,
+			}
+
+			pool.Register <- client
+			poolMap[observation.Attribute+"|"+observation.SupertypeID] = pool
+		}
+
 	}
 }

--- a/pkg/storage/dynamo/producingRepository.go
+++ b/pkg/storage/dynamo/producingRepository.go
@@ -3,6 +3,8 @@ package dynamo
 import (
 	"time"
 
+	"github.com/super-type/supertype/pkg/http/websocket"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
@@ -58,6 +60,11 @@ func (d *Storage) Produce(o producing.ObservationRequest) error {
 		color.Red("Failed to write to database")
 		return storage.ErrFailedToWriteDB
 	}
+
+	// todo is this kind of crossing bounded contexts? I feel like we shouldn't be calling a handler from a service
+	// todo this is where we should get the right re-encyrption data and send it over if we want E2E-encrypted data
+	// Broadcast to all listening clients...
+	websocket.BroadcastForSpecificPool(o.Attribute+"|"+o.SupertypeID, "test")
 
 	return nil
 }

--- a/pkg/storage/redis/cacheRepository.go
+++ b/pkg/storage/redis/cacheRepository.go
@@ -3,7 +3,6 @@ package redis
 import (
 	"github.com/fatih/color"
 	"github.com/go-redis/redis"
-	"github.com/google/uuid"
 	"github.com/super-type/supertype/pkg/caching"
 	"github.com/super-type/supertype/pkg/storage/dynamo"
 )
@@ -21,7 +20,6 @@ func (d *Storage) Subscribe(c caching.WSObservationRequest) error {
 		return err
 	}
 
-	// Example new client
 	rdb, err := EstablishRedisConnection()
 	if err != nil {
 		return err
@@ -34,25 +32,6 @@ func (d *Storage) Subscribe(c caching.WSObservationRequest) error {
 	}
 
 	return nil
-}
-
-// GenerateConnectionID generates connection IDs for WebSocket connections
-func (d *Storage) GenerateConnectionID() (*string, error) {
-	// Example new client
-	rdb, err := EstablishRedisConnection()
-	if err != nil {
-		return nil, err
-	}
-	color.Cyan("Connected to Redis cache for GenerateConnectionId...")
-
-	cid := uuid.New().String()
-	for ok := true; ok; ok = rdb.Exists(cid).Val() > 0 {
-		// todo this always triggers once... is there a way to avoid this?
-		color.Yellow("Connection ID already exists... retrying...")
-		cid = uuid.New().String()
-	}
-
-	return &cid, nil
 }
 
 // GetSubscribers gets all subscribers of the Redis set


### PR DESCRIPTION
* Removes internal creation of unique connection IDs and relies on gorilla's websocket functionality to keep track of clients
* Creates pools based on the form `<attribute>|<supertypeID>` in order to track which observations should be sent where
* On produce, data is sent to the proper consumers listening on that `<attribute>|<supertypeID>` pool