### PR TITLE
Repurposing vendor secret key as an API Key for incoming requests, used in header

### DIFF
--- a/pkg/authenticating/vendor.go
+++ b/pkg/authenticating/vendor.go
@@ -22,7 +22,7 @@ type CreateVendor struct {
 	BusinessName   string               `json:"businessName"`
 	Username       string               `json:"username"`
 	PublicKey      string               `json:"pk"`
-	SkHash         string               `json:"skHash"`
+	APIKeyHash     string               `json:"apiKeyHash"`
 	SupertypeID    string               `json:"supertypeID"`
 	Connections    map[string][2]string `json:"connections"`
 	AccountBalance float32              `json:"accountBalance"`

--- a/pkg/consuming/observation.go
+++ b/pkg/consuming/observation.go
@@ -5,16 +5,6 @@ type ObservationRequest struct {
 	Attribute   string `json:"attribute"`
 	SupertypeID string `json:"supertypeID"`
 	PublicKey   string `json:"pk"`
-	SkHash      string `json:"skHash"`
-}
-
-// WSObservationRequest defines an encrypted vendor observation request with a connection id
-type WSObservationRequest struct {
-	Attribute   string `json:"attribute"`
-	SupertypeID string `json:"supertypeID"`
-	PublicKey   string `json:"pk"`
-	SkHash      string `json:"skHash"`
-	Cid         string `json:"cid"`
 }
 
 // ObservationResponse defines an encrypted vendor observation response

--- a/pkg/consuming/service.go
+++ b/pkg/consuming/service.go
@@ -2,12 +2,12 @@ package consuming
 
 // Repository provides access to relevant storage
 type repository interface {
-	Consume(ObservationRequest) (*[]ObservationResponse, error)
+	Consume(ObservationRequest, string) (*[]ObservationResponse, error)
 }
 
 // Service provides consuming operations
 type Service interface {
-	Consume(ObservationRequest) (*[]ObservationResponse, error)
+	Consume(ObservationRequest, string) (*[]ObservationResponse, error)
 }
 
 type service struct {
@@ -20,8 +20,8 @@ func NewService(r repository) Service {
 }
 
 // Consume consumes encrypted data from Supertype and returns it to vendors
-func (s *service) Consume(o ObservationRequest) (*[]ObservationResponse, error) {
-	observation, err := s.r.Consume(o)
+func (s *service) Consume(o ObservationRequest, apiKeyHash string) (*[]ObservationResponse, error) {
+	observation, err := s.r.Consume(o, apiKeyHash)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dashboard/observation.go
+++ b/pkg/dashboard/observation.go
@@ -1,0 +1,8 @@
+package dashboard
+
+// ObservationRequest defines an encrypted vendor observation request
+type ObservationRequest struct {
+	Attribute   string `json:"attribute"`
+	SupertypeID string `json:"supertypeID"`
+	PublicKey   string `json:"pk"`
+}

--- a/pkg/dashboard/service.go
+++ b/pkg/dashboard/service.go
@@ -2,12 +2,12 @@ package dashboard
 
 // Repository provides access to relevant storage
 type repository interface {
-	ListObservations() ([]string, error)
+	ListObservations(ObservationRequest, string) ([]string, error)
 }
 
 // Service provides dashboard operations
 type Service interface {
-	ListObservations() ([]string, error)
+	ListObservations(ObservationRequest, string) ([]string, error)
 }
 
 type service struct {
@@ -20,8 +20,8 @@ func NewService(r repository) Service {
 }
 
 // ListObservations lists all observations in the Supertype ecosystem
-func (s *service) ListObservations() ([]string, error) {
-	res, err := s.r.ListObservations()
+func (s *service) ListObservations(o ObservationRequest, apiKeyHash string) ([]string, error) {
+	res, err := s.r.ListObservations(o, apiKeyHash)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/http/util.go
+++ b/pkg/http/util.go
@@ -11,7 +11,7 @@ import (
 func LocalHeaders(w http.ResponseWriter, r *http.Request) (*json.Decoder, error) {
 	(w).Header().Set("Access-Control-Allow-Origin", "*")
 	(w).Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-	(w).Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+	(w).Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-API-Key")
 	// todo we may still want to leave this but unsure
 	if (r).Method == "OPTIONS" {
 		return nil, errors.New("OPTIONS")

--- a/pkg/producing/observation.go
+++ b/pkg/producing/observation.go
@@ -6,6 +6,5 @@ type ObservationRequest struct {
 	Ciphertext  string `json:"ciphertext"`
 	PublicKey   string `json:"pk"`
 	SupertypeID string `json:"supertypeID"`
-	SkHash      string `json:"skHash"`
 	IV          string `json:"iv"`
 }

--- a/pkg/producing/service.go
+++ b/pkg/producing/service.go
@@ -2,12 +2,12 @@ package producing
 
 // Repository provides access to relevant storage
 type repository interface {
-	Produce(ObservationRequest) error
+	Produce(ObservationRequest, string) error
 }
 
 // Service provides producing operations
 type Service interface {
-	Produce(ObservationRequest) error
+	Produce(ObservationRequest, string) error
 }
 
 type service struct {
@@ -20,8 +20,8 @@ func NewService(r repository) Service {
 }
 
 // Produce produces encrypted data to Supertype
-func (s *service) Produce(o ObservationRequest) error {
-	err := s.r.Produce(o)
+func (s *service) Produce(o ObservationRequest, apiKeyHash string) error {
+	err := s.r.Produce(o, apiKeyHash)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/dynamo/authenticatingImpl.go
+++ b/pkg/storage/dynamo/authenticatingImpl.go
@@ -80,9 +80,8 @@ func (d *Storage) CreateVendor(v authenticating.Vendor) (*[2]string, error) {
 
 	// Generate hash of secret key to be used as a signing measure for producing/consuming data
 	h := sha256.New()
-	// h.Write([]byte(utils.PrivateKeyToString(skVendor)))
 	h.Write([]byte(*skVendor))
-	skHash := hex.EncodeToString(h.Sum(nil))
+	apiKeyHash := hex.EncodeToString(h.Sum(nil))
 
 	// Generate Supertype ID
 	supertypeID, err := utils.GenerateSupertypeID(v.Password)
@@ -103,7 +102,7 @@ func (d *Storage) CreateVendor(v authenticating.Vendor) (*[2]string, error) {
 		BusinessName:   v.BusinessName,
 		Username:       v.Username,
 		PublicKey:      *pkVendor,
-		SkHash:         skHash,
+		APIKeyHash:     apiKeyHash,
 		SupertypeID:    *supertypeID,
 		AccountBalance: 0.0,
 	}

--- a/pkg/storage/dynamo/consumingImpl.go
+++ b/pkg/storage/dynamo/consumingImpl.go
@@ -10,16 +10,16 @@ import (
 )
 
 // Consume returns all observations at the requested attribute for the specified Supertype entity
-func (d *Storage) Consume(c consuming.ObservationRequest) (*[]consuming.ObservationResponse, error) {
-	skHash, err := ScanDynamoDBWithKeyCondition("vendor", "skHash", "pk", c.PublicKey)
-	if err != nil {
+func (d *Storage) Consume(c consuming.ObservationRequest, apiKeyHash string) (*[]consuming.ObservationResponse, error) {
+	databaseAPIKeyHash, err := ScanDynamoDBWithKeyCondition("vendor", "apiKeyHash", "pk", c.PublicKey)
+	if err != nil || databaseAPIKeyHash == nil {
 		return nil, err
 	}
 
-	// Compare requesting skHash with our internal skHash. If they don't match, it's not coming from the vendor
-	if *skHash != c.SkHash {
+	// Compare requesting API Key with our internal API Key. If they don't match, it's not coming from the vendor
+	if *databaseAPIKeyHash != apiKeyHash {
 		color.Red("!!! Vendor secret key hashes do no match - potential malicious attempt !!!")
-		return nil, storage.ErrSkHashDoesNotMatch
+		return nil, storage.ErrAPIKeyDoesNotMatch
 	}
 
 	// Initialize AWS session

--- a/pkg/storage/dynamo/dynamoObjects.go
+++ b/pkg/storage/dynamo/dynamoObjects.go
@@ -26,5 +26,4 @@ type Observation struct {
 	DateAdded   string `json:"dateAdded"`
 	PublicKey   string `json:"pk"`
 	SupertypeID string `json:"supertypeID"`
-	SkHash      string `json:"skHash"`
 }

--- a/pkg/storage/dynamo/util.go
+++ b/pkg/storage/dynamo/util.go
@@ -63,7 +63,6 @@ func ScanDynamoDB(table string, attribute string, value string) (*dynamodb.ScanO
 func ScanDynamoDBWithKeyCondition(table string, attribute string, keyCondition string, keyConditionValue string) (*string, error) {
 	svc := utils.SetupAWSSession()
 
-	// Get the skHash of the given vendor
 	scanInput := &dynamodb.ScanInput{
 		ExpressionAttributeNames: map[string]*string{
 			"#" + attribute: aws.String(attribute),

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -23,8 +23,8 @@ var ErrGetListPublicKeys = errors.New("Error getting list of public keys")
 // ErrNoObservationsForEntity is used when a vendor requests an observation for an entity who has no observations
 var ErrNoObservationsForEntity = errors.New("No observations found for entity")
 
-// ErrSkHashDoesNotMatch is used when secret keys do not match, which may flag a potential malicious attempt...
-var ErrSkHashDoesNotMatch = errors.New("Secret keys do not match... Potential malicious event")
+// ErrAPIKeyDoesNotMatch is used when API keys do not match, which may flag a potential malicious attempt...
+var ErrAPIKeyDoesNotMatch = errors.New("API keys do not match... Potential malicious event")
 
 // ErrInvalidEmail is used when a user attempts to use an invalid email address
 var ErrInvalidEmail = errors.New("Invalid email")


### PR DESCRIPTION
* Repurpose `skHash` into API Key
* Clean up old code relating to Websockets that I previously missed 
* Require `X-API-Key` header for authenticated requests
* Add `X-API-Key` to accepted headers