### PR TITLE
Remove requirement for customers to send their public key in requests to Supertype API

### DIFF
--- a/pkg/storage/dynamo/consumingImpl.go
+++ b/pkg/storage/dynamo/consumingImpl.go
@@ -11,7 +11,7 @@ import (
 
 // Consume returns all observations at the requested attribute for the specified Supertype entity
 func (d *Storage) Consume(c consuming.ObservationRequest, apiKeyHash string) (*[]consuming.ObservationResponse, error) {
-	databaseAPIKeyHash, err := ScanDynamoDBWithKeyCondition("vendor", "apiKeyHash", "pk", c.PublicKey)
+	databaseAPIKeyHash, err := ScanDynamoDBWithKeyCondition("vendor", "apiKeyHash", "apiKeyHash", apiKeyHash)
 	if err != nil || databaseAPIKeyHash == nil {
 		return nil, err
 	}

--- a/pkg/storage/dynamo/dashboardImpl.go
+++ b/pkg/storage/dynamo/dashboardImpl.go
@@ -11,7 +11,7 @@ import (
 
 // ListObservations returns all observations in the Supertype ecosystem
 func (d *Storage) ListObservations(o dashboard.ObservationRequest, apiKeyHash string) ([]string, error) {
-	databaseAPIKeyHash, err := ScanDynamoDBWithKeyCondition("vendor", "apiKeyHash", "pk", o.PublicKey)
+	databaseAPIKeyHash, err := ScanDynamoDBWithKeyCondition("vendor", "apiKeyHash", "apiKeyHash", apiKeyHash)
 	if err != nil || databaseAPIKeyHash == nil {
 		return nil, err
 	}

--- a/pkg/storage/dynamo/producingImpl.go
+++ b/pkg/storage/dynamo/producingImpl.go
@@ -1,6 +1,7 @@
 package dynamo
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -13,8 +14,14 @@ import (
 
 // Produce produces encyrpted data to Supertype
 func (d *Storage) Produce(o producing.ObservationRequest, apiKeyHash string) error {
-	databaseAPIKeyHash, err := ScanDynamoDBWithKeyCondition("vendor", "apiKeyHash", "pk", o.PublicKey)
+	databaseAPIKeyHash, err := ScanDynamoDBWithKeyCondition("vendor", "apiKeyHash", "apiKeyHash", apiKeyHash)
 	if err != nil || databaseAPIKeyHash == nil {
+		return err
+	}
+
+	pk, err := ScanDynamoDBWithKeyCondition("vendor", "pk", "apiKeyHash", apiKeyHash)
+	if err != nil || databaseAPIKeyHash == nil {
+		fmt.Println(err)
 		return err
 	}
 
@@ -34,7 +41,7 @@ func (d *Storage) Produce(o producing.ObservationRequest, apiKeyHash string) err
 	d.Observation = Observation{
 		Ciphertext:  o.Ciphertext + "|" + o.IV + "|" + o.Attribute,
 		DateAdded:   currentTime.Format("2006-01-02 15:04:05.000000000"),
-		PublicKey:   o.PublicKey,
+		PublicKey:   *pk,
 		SupertypeID: o.SupertypeID,
 	}
 


### PR DESCRIPTION
* Looks up user information based on given API Key header
* In `Consume()` - public key is associated with the user given their (verified) API Key, so that the user doesn't have to send across a `pk` using the client libraries 